### PR TITLE
Fix url because render changed their pricing model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-# Tools & co
+# [Tools & co](https://toolsandco-ycuc.onrender.com/)
 
 _Tools&Co gives people the ability to rent various tools and achieve their DIY dreams 🤩_
 
-<div id="screenshot"><a href="https://toolsandco.onrender.com/"><img src="./toolsandco-screenshot.png"></a></div>
-
-## [toolsandco.onrender.com](https://toolsandco.onrender.com/)
+<div id="screenshot"><a href="https://toolsandco-ycuc.onrender.com/"><img src="./toolsandco-screenshot.png"></a></div>
 
 Tools&Co is a FullStack web application made by [@bapturp](https://github.com/bapturp) [@hugoviolas](https://github.com/hugoviolas) and [@inesza](https://github.com/inesza) during the [Ironhack Web Development Bootcamp](https://www.ironhack.com/en/web-development) in only **4 days** 🚀
 


### PR DESCRIPTION
I had to redeploy the website because we were using a team on render.com and starting January 1st, 2023, they charge ~50$ per month for a team with 3 people.
I've removed the team, and consequently the project and deploy it again on my personal account.
The side effect of that is the URL has changed, it's now https://toolsandco-ycuc.onrender.com/, it doesn't seems I can change it once it's generated by render.com.